### PR TITLE
Dump build logs if mock fails

### DIFF
--- a/input/build-from-github
+++ b/input/build-from-github
@@ -8,10 +8,11 @@ echo "type=git url=/$REPO_NAME name=$REPO_NAME tarball=$TARBALL_NAME tag=HEAD ha
 
 # Run osg-build
 osg-build --verbose mock .
-
+ret=$?
 if [ $? -ne 0 ]; then
-    for build_log in state.log root.log build.log; do
+    for build_log in root.log build.log; do
         echo "### $build_log ###"
         cat /u/_build_results/$build_log
     done
 fi
+exit $ret

--- a/input/build-from-github
+++ b/input/build-from-github
@@ -9,7 +9,7 @@ echo "type=git url=/$REPO_NAME name=$REPO_NAME tarball=$TARBALL_NAME tag=HEAD ha
 # Run osg-build
 osg-build --verbose mock .
 ret=$?
-if [ $? -ne 0 ]; then
+if [ $ret -ne 0 ]; then
     for build_log in root.log build.log; do
         echo "### $build_log ###"
         cat /u/_build_results/$build_log

--- a/input/build-from-github
+++ b/input/build-from-github
@@ -8,3 +8,10 @@ echo "type=git url=/$REPO_NAME name=$REPO_NAME tarball=$TARBALL_NAME tag=HEAD ha
 
 # Run osg-build
 osg-build --verbose mock .
+
+if [ $? -ne 0 ]; then
+    for build_log in state.log root.log build.log; do
+        echo "### $build_log ###"
+        cat /u/_build_results/$build_log
+    done
+fi


### PR DESCRIPTION
Tested this locally to troubleshoot https://github.com/opensciencegrid/xcache/pull/63 and found the root cause of the problem:

> BUILDSTDERR: install: cannot stat 'configs/common-cache/config.d/40-osg-caching-plugin.cfg': No such file or directory