### PR TITLE
Add singularity/apptainer build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/osg_build.tar
+/osg_build.sif

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 osg_build.tar: Dockerfile input/* buildbuilder
 	$(dobuild)
 	-rm -f $@.new
-	# have to do this in two steps because docker save won't overwrite an existing file
+# have to do this in two steps because docker save won't overwrite an existing file
 	"$(DOCKER)" save -o $@.new "$(OSG_BUILD_IMAGE)"
 	mv -f $@.new $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+OSG_BUILD_IMAGE ?= opensciencegrid/osg-build:latest
+OSG_BUILD_REPO ?= opensciencegrid
+OSG_BUILD_BRANCH ?= master
+DOCKER ?= docker
+SINGULARITY ?= singularity
+
+.PHONY: all clean
+
+all: osg_build.sif osg_build.tar
+
+clean:
+	rm -f osg_build.tar osg_build.sif
+
+# $@ is the target; $< is the first dependency
+
+osg_build.tar: Dockerfile input/* buildbuilder
+	DOCKER="$(DOCKER)" \
+	OSG_BUILD_IMAGE="$(OSG_BUILD_IMAGE)" \
+	OSG_BUILD_REPO="$(OSG_BUILD_REPO)" \
+	OSG_BUILD_BRANCH="$(OSG_BUILD_BRANCH)" \
+		./buildbuilder
+	"$(DOCKER)" save -o $@ "$(OSG_BUILD_IMAGE)"
+
+osg_build.sif: osg_build.def osg_build.tar
+	"$(SINGULARITY)" build $@ $<
+

--- a/Makefile
+++ b/Makefile
@@ -4,23 +4,33 @@ OSG_BUILD_BRANCH ?= master
 DOCKER ?= docker
 SINGULARITY ?= singularity
 
+define dobuild =
+DOCKER="$(DOCKER)" \
+OSG_BUILD_IMAGE="$(OSG_BUILD_IMAGE)" \
+OSG_BUILD_REPO="$(OSG_BUILD_REPO)" \
+OSG_BUILD_BRANCH="$(OSG_BUILD_BRANCH)" \
+./buildbuilder
+endef
+
 .PHONY: all clean
 
 all: osg_build.sif osg_build.tar
 
 clean:
-	rm -f osg_build.tar osg_build.sif
+	-rm -f osg_build.tar osg_build.sif osg_build.tar.new
 
 # $@ is the target; $< is the first dependency
 
 osg_build.tar: Dockerfile input/* buildbuilder
-	DOCKER="$(DOCKER)" \
-	OSG_BUILD_IMAGE="$(OSG_BUILD_IMAGE)" \
-	OSG_BUILD_REPO="$(OSG_BUILD_REPO)" \
-	OSG_BUILD_BRANCH="$(OSG_BUILD_BRANCH)" \
-		./buildbuilder
-	"$(DOCKER)" save -o $@ "$(OSG_BUILD_IMAGE)"
+	$(dobuild)
+	-rm -f $@.new
+	# have to do this in two steps because docker save won't overwrite an existing file
+	"$(DOCKER)" save -o $@.new "$(OSG_BUILD_IMAGE)"
+	mv -f $@.new $@
 
 osg_build.sif: osg_build.def osg_build.tar
 	"$(SINGULARITY)" build $@ $<
 
+.PHONY: build
+build:
+	$(dobuild)

--- a/buildbuilder
+++ b/buildbuilder
@@ -1,2 +1,14 @@
 #!/bin/bash
-exec docker build "$@" . --tag opensciencegrid/osg-build:latest
+
+: "${OSG_BUILD_IMAGE:=opensciencegrid/osg-build:latest}"
+: "${OSG_BUILD_REPO:=opensciencegrid}"
+: "${OSG_BUILD_BRANCH:=master}"
+: "${DOCKER:=docker}"
+
+exec "${DOCKER}" build \
+    --build-arg=OSG_BUILD_REPO="${OSG_BUILD_REPO}" \
+    --build-arg=OSG_BUILD_BRANCH="${OSG_BUILD_BRANCH}" \
+    --tag "${OSG_BUILD_IMAGE}" \
+    --squash \
+    -f Dockerfile
+

--- a/osg_build.def
+++ b/osg_build.def
@@ -1,0 +1,2 @@
+Bootstrap: docker-archive
+From: osg_build.tar


### PR DESCRIPTION
This adds a Makefile; running `make osg_build.sif` (or just `make all`) will build the docker image, export it to a tarball, then turn it into a SIF file.

If you just want to do a build of the docker image, run `make build`.