### PR TITLE
Install and use tini as our command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
    buildsys-macros \
    buildsys-srpm-build \
    'osg-build-deps >= 4' \
+   tini \
    globus-proxy-utils \
    # ^^ sorry, but voms-proxy-init gives me "verification failed" \
    osg-ca-certs && \
@@ -54,3 +55,5 @@ WORKDIR /home/build
 
 # The koji-hub server to use
 ENV KOJI_HUB=koji.opensciencegrid.org
+
+CMD tini -- sleep infinity

--- a/osg_build.def
+++ b/osg_build.def
@@ -1,2 +1,9 @@
 Bootstrap: docker-archive
 From: osg_build.tar
+
+%runscript
+    #!/bin/bash
+    command=${1:-bash}
+    shift
+    exec "$command" "$@"
+


### PR DESCRIPTION
This allows receiving signals that stop the container.

We only want that for the docker image; for Singularity, run a shell.